### PR TITLE
create page container and add to pages

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -14,10 +14,9 @@ body {
 }
 
 #menu-container {
-  width: 60%;
-  border: 20px solid #666666;
+  width: 50%;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-evenly;
-  margin-left: 20%;
+  margin-left: 25%;
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -35,14 +35,17 @@ const App = () => {
               <Route
                 path="/current-projects"
                 element={<CurrentProjects />}
-              ></Route>
+              />
               <Route 
                 path="/choose-existing-template" 
                 element={<TemplateSearch />}
               />
+              <Route
+                path="/test"
+                element={<Test />}
+              />
             </Routes>
           </main>
-          <Test />
         </TemplateContext.Provider>
       </ProjectContext.Provider>
     </UserContext.Provider>

--- a/client/src/components/HomePage.js
+++ b/client/src/components/HomePage.js
@@ -6,14 +6,11 @@ import { FolderFill } from "react-bootstrap-icons";
 import { PlusCircleFill } from "react-bootstrap-icons";
 import { PersonFill } from "react-bootstrap-icons";
 import { ArchiveFill } from "react-bootstrap-icons";
+import PageContainer from "./PageContainer";
 
 const HomePage = () => {
   return (
-    <div>
-      <header id="home-header">
-        <h1>ANDevelop</h1>
-        <h2>Welcome</h2>
-      </header>
+    <PageContainer pageTitle="Welcome">
       <main id="menu-container">
         <div className="menu-item">
           <FolderFill size={90} />
@@ -40,7 +37,7 @@ const HomePage = () => {
           <Button variant="dark">Archived Projects</Button>
         </div>
       </main>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/client/src/components/PageContainer.js
+++ b/client/src/components/PageContainer.js
@@ -1,0 +1,25 @@
+import React from "react";
+import Button from "react-bootstrap/Button";
+import { NavLink } from "react-router-dom";
+import "./css/pageContainer.css";
+
+const PageContainer = ({ pageTitle, buttonText, buttonTo, children }) => {
+  return (
+    <div id="page">
+      <header id="page-header">
+        <div id="and-develop">ANDevelop</div>
+        <h1 id="page-title">{pageTitle}</h1>
+      </header>
+      {buttonText && buttonTo && (
+        <NavLink to={buttonTo} id="button">
+          <Button variant="dark">{buttonText}</Button>
+        </NavLink>
+      )}
+      <main id="outer-container">
+        <div id="inner-container">{children}</div>
+      </main>
+    </div>
+  );
+};
+
+export default PageContainer;

--- a/client/src/components/css/pageContainer.css
+++ b/client/src/components/css/pageContainer.css
@@ -1,0 +1,43 @@
+#page {
+  background-color: #dddddd;
+  display: flex;
+  flex-direction: column;
+  padding: 50px;
+  height: 100vh;
+}
+
+#page-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 60px;
+  color: #cf2a27;
+}
+
+#and-develop {
+  font-size: 2.5rem;
+}
+
+#page-title {
+  margin: 0;
+}
+
+#outer-container {
+  border: solid black 4px;
+  padding: 10px;
+  background-color: #666666;
+  border-radius: 3px;
+}
+
+#inner-container {
+  border: solid black 4px;
+  border-radius: 3px;
+  background-color: #dddddd;
+  min-height: 50vh;
+  padding: 30px;
+}
+
+#button {
+  margin-top: -46px;
+  margin-bottom: 8px;
+}

--- a/client/src/components/currentProjects.js
+++ b/client/src/components/currentProjects.js
@@ -1,17 +1,17 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
 import Button from "react-bootstrap/Button";
+import PageContainer from "./PageContainer";
 
 function CurrentProjects() {
   return (
-    <section>
-      <NavLink to="/">
-        <Button variant="dark">Close</Button>
-      </NavLink>
-      <article>A live project will be displayed here</article>
-      <article>A live project will be displayed here</article>
-      <article>A live project will be displayed here</article>
-    </section>
+    <PageContainer buttonText="Close" buttonTo="/">
+      <section>
+        <article>A live project will be displayed here</article>
+        <article>A live project will be displayed here</article>
+        <article>A live project will be displayed here</article>
+      </section>
+    </PageContainer>
   );
 }
 

--- a/client/src/components/templateRoute.js
+++ b/client/src/components/templateRoute.js
@@ -1,48 +1,50 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
 import Button from "react-bootstrap/Button";
+import PageContainer from "./PageContainer";
 
 function TemplateRoute() {
   return (
-    <section>
-      <header>
-        <NavLink to="/">
-          <Button variant="dark">Close</Button>
-        </NavLink>
-        <h2>Create New Project</h2>
-      </header>
-      <div>
-        <section id="create-template">
-          <NavLink to="">
-            <button className="" disabled>
-              Create a new template
-            </button>
-          </NavLink>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-            culpa qui officia deserunt mollit anim id est laborum.
-          </p>
-        </section>
-        <section id="choose-template">
-          <NavLink to="/choose-existing-template">
-            <button className="">Select exiting template</button>
-          </NavLink>
-          <p>
-            Mattis pellentesque id nibh tortor id aliquet lectus. Ut sem nulla
-            pharetra diam. Lobortis feugiat vivamus at augue. Faucibus interdum
-            posuere lorem ipsum dolor sit amet. Varius duis at consectetur lorem
-            donec massa. Massa tincidunt nunc pulvinar sapien et ligula
-            ullamcorper malesuada proin. Nunc sed velit dignissim sodales ut eu.
-            Integer vitae justo eget magna fermentum iaculis eu non diam.
-          </p>
-        </section>
-      </div>
-    </section>
+    <PageContainer
+      pageTitle="Create New Project"
+      buttonText="Close"
+      buttonTo="/"
+    >
+      <section>
+        <div>
+          <section id="create-template">
+            <NavLink to="">
+              <button className="" disabled>
+                Create a new template
+              </button>
+            </NavLink>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+              reprehenderit in voluptate velit esse cillum dolore eu fugiat
+              nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+              sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+          </section>
+          <section id="choose-template">
+            <NavLink to="/setup-project">
+              <button className="">Select exiting template</button>
+            </NavLink>
+            <p>
+              Mattis pellentesque id nibh tortor id aliquet lectus. Ut sem nulla
+              pharetra diam. Lobortis feugiat vivamus at augue. Faucibus
+              interdum posuere lorem ipsum dolor sit amet. Varius duis at
+              consectetur lorem donec massa. Massa tincidunt nunc pulvinar
+              sapien et ligula ullamcorper malesuada proin. Nunc sed velit
+              dignissim sodales ut eu. Integer vitae justo eget magna fermentum
+              iaculis eu non diam.
+            </p>
+          </section>
+        </div>
+      </section>
+    </PageContainer>
   );
 }
 


### PR DESCRIPTION
Create page container to be used across all pages

Props accepted:
- `pageTitle` for the top left title on the screen
- `buttonText` for the text of a button above the central container
- `buttonTo` to pass in the route of the button

I have added this to some pages that are already set up

<img width="1295" alt="image" src="https://user-images.githubusercontent.com/114083771/197809234-addb6e1f-fccd-43de-8720-af737e551ef8.png">

<img width="1300" alt="image" src="https://user-images.githubusercontent.com/114083771/197809141-a90908fa-017a-4ef1-9cbf-c7b347514c9f.png">

